### PR TITLE
Ensures project can compile for latest zig 0.10.0 release

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2021 Rémy Mathieu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/forwarder.zig
+++ b/src/forwarder.zig
@@ -62,7 +62,7 @@ pub const Forwarder = struct {
 
             // try to send the transaction
             send_http_request(allocator, config, tx) catch |err| {
-                std.log.warn("can't send a transaction: {s}\nstoring the transaction of size {d} bytes [{s}]", .{ err, tx.data.items.len, tx.data.items });
+                std.log.warn("can't send a transaction: {s}\nstoring the transaction of size {d} bytes [{s}]", .{ @errorName(err), tx.data.items.len, tx.data.items });
 
                 // limit the amount of transactions stored
                 if (self.transactions.items.len > max_stored_transactions) {
@@ -72,7 +72,7 @@ pub const Forwarder = struct {
                 }
 
                 self.transactions.append(tx) catch |err2| {
-                    std.log.warn("can't store the failing transaction {s}", .{err2});
+                    std.log.warn("can't store the failing transaction {s}", .{@errorName(err2)});
                     tx.deinit();
                 };
                 return;
@@ -121,12 +121,12 @@ pub const Forwarder = struct {
             }
             var tx = self.transactions.orderedRemove(0);
             send_http_request(allocator, config, tx) catch |err| {
-                std.log.warn("error while retrying a transaction: {s}", .{err});
+                std.log.warn("error while retrying a transaction: {s}", .{@errorName(err)});
                 if (tx.tries < max_retry_per_transaction) {
                     tx.tries += 1;
                     self.transactions.append(tx) catch |err2| {
                         tx.deinit();
-                        std.log.err("can't store the failing transaction {s}", .{err2});
+                        std.log.err("can't store the failing transaction {s}", .{@errorName(err2)});
                     };
                 } else {
                     tx.deinit();
@@ -199,8 +199,6 @@ pub const Forwarder = struct {
     }
 
     fn send_http_request(allocator: std.mem.Allocator, config: Config, tx: *Transaction) !void {
-        _ = c.curl_global_init(c.CURL_GLOBAL_ALL);
-
         var failed: bool = false;
         var curl: ?*c.CURL = null;
         var res: c.CURLcode = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -89,7 +89,7 @@ pub fn main() !void {
                     i += 1;
                 }
             } else |err| {
-                std.log.err("can't parse packet: {s}", .{err});
+                std.log.err("can't parse packet: {s}", .{@errorName(err)});
                 std.log.err("packet: {s}", .{node.data.payload});
             }
 
@@ -111,7 +111,7 @@ pub fn main() !void {
 
         if (std.time.milliTimestamp() > next_flush) {
             sampler.flush(config) catch |err| {
-                std.log.err("can't flush: {s}", .{err});
+                std.log.err("can't flush: {s}", .{@errorName(err)});
             };
 
             std.log.info("packets parsed: {d}/s", .{@divTrunc(packets_parsed, (flush_frequency / 1000))});

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -51,7 +51,7 @@ pub const Parser = struct {
 
         while (part != null) {
             var m: metric.Metric = try parse_metric(allocator, part.?);
-            _ = try rv.append(m);
+            try rv.append(m);
             part = iterator.next();
         }
 
@@ -120,7 +120,7 @@ pub const Parser = struct {
         var iterator = std.mem.split(u8, buffer[1..buffer.len], ",");
         var part: ?[]const u8 = iterator.next();
         while (part != null) {
-            _ = try rv.append(part.?);
+            try rv.append(part.?);
             part = iterator.next();
         }
 

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -57,7 +57,7 @@ pub const Sampler = struct {
             }
             self.mutex.lock();
             defer self.mutex.unlock();
-            _ = try self.map.put(h, newSample);
+            try self.map.put(h, newSample);
             return;
         }
 
@@ -66,7 +66,7 @@ pub const Sampler = struct {
         std.mem.copy(u8, name, m.name);
         self.mutex.lock();
         defer self.mutex.unlock();
-        _ = try self.map.put(h, Sample{
+        try self.map.put(h, Sample{
             .metric_name = name,
             .metric_type = m.type,
             .samples = 1,


### PR DESCRIPTION
- Adds license.md just as a precaution (same as specified in README)
- Fixes compiler warnings (at least on my machine) with using the `{s}` verb on an error set.
- Removes the global curl init, as easy_init does it for you as far as I can tell. 
- Removes unnecessary discards of function calls that return `!void`. 